### PR TITLE
Fix usart1 initialization

### DIFF
--- a/program/mcu_periph/usart.c
+++ b/program/mcu_periph/usart.c
@@ -16,9 +16,10 @@
 static void enable_usart1(void)
 {
 	/* RCC Initialization */
-	RCC_AHB1PeriphClockCmd(RCC_APB2Periph_USART1, ENABLE);
+	RCC_APB2PeriphClockCmd(RCC_APB2Periph_USART1, ENABLE);
 
-	RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_DMA1, ENABLE);
+	//RCC_AHB1PeriphClockCmd(RCC_AHB1Periph_DMA1, ENABLE);
+
 	/* GPIO Initialization */
 	GPIO_InitTypeDef GPIO_InitStruct = {
 		.GPIO_Pin = GPIO_Pin_9 | GPIO_Pin_10,


### PR DESCRIPTION
https://github.com/UrsusPilot/firmware/blob/master/program/mcu_periph/usart.c#L19

(1.)In function "enable_usart1(void)":
line 19, the original code initialize the "RCC_APB2Periph_USART1" by calling function "RCC_AHB1PeriphClockCmd". I found this is wrong beacuse USART1 is not a member of AHB1.
So we should fix this error by using the function "RCC_APB2PeriphClockCmd".

(2.)Also block the DMA initialization at line 21 because it is not be using right now